### PR TITLE
Ddp kwargs

### DIFF
--- a/tez/model/tez.py
+++ b/tez/model/tez.py
@@ -38,6 +38,8 @@ class Tez:
     num_train_steps: Optional[int] = None
     num_valid_steps: Optional[int] = None
 
+    find_unused_parameters: Optional[bool] = False
+
     # internals
     current_epoch = 0
     train_batch_index = 0
@@ -65,8 +67,6 @@ class Tez:
     metrics["test"] = {}
     _progress = None
 
-    find_unused_parameters = False
-
     def _init_driver(self):
         if self.config.fp16 is True and self.config.bf16 is True:
             raise ValueError("Only one of fp16 and bf16 can be True")
@@ -81,7 +81,7 @@ class Tez:
         kwargs_handlers = None
         if self.find_unused_parameters:
             kwargs_handlers = [DistributedDataParallelKwargs(find_unused_parameters=True)]
-            
+
         self._driver = Accelerator(
             device_placement=True,
             step_scheduler_with_optimizer=False,


### PR DESCRIPTION
I made a custom model and I got this error: 

```
RuntimeError: Expected to have finished reduction in the prior iteration before 
starting a new one. This error indicates that your module has parameters that 
were not used in producing loss. You can enable unused parameter detection by 
passing the keyword argument `find_unused_parameters=True` to 
`torch.nn.parallel.DistributedDataParallel`, 
and by making sure all `forward` function outputs participate in calculating loss. 

If you already have done the above, then the distributed data parallel module 
wasn't able to locate the output tensors in the return value of your module's 
`forward` function. Please include the loss function and the structure of the 
return value of `forward` of your module when reporting this issue (e.g. list, 
dict, iterable).
```


I found [this issue in the accelerate repo](https://github.com/huggingface/accelerate/issues/24) which indicated that the solution was to do the following

```python
from accelerate import DistributedDataParallelKwargs

ddp_kwargs = DistributedDataParallelKwargs(find_unused_parameters=True)
accelerator = Accelerator(kwargs_handlers=[ddp_kwargs])
```

I added another argument to `Tez` that allows the user to set that.